### PR TITLE
fix(docs): update standalone install instructions for multi-file zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,22 @@ OpenCode is an AI-powered coding assistant for the terminal. It uses [Bun](https
 
 ### Option 1: Standalone binary (easiest)
 
+> **Note:** The zip now contains a wrapper script (`opencode`), the main binary
+> (`opencode.bin`), and native libraries (`.so` files). All files must be
+> installed to their proper locations.
+
 ```bash
-# Download and install
-curl -LO https://github.com/guysoft/opencode-termux/releases/latest/download/opencode-aarch64.zip
-unzip opencode-aarch64.zip
-chmod +x opencode
-mv opencode $PREFIX/bin/
+# Download the latest "opencode-*-android-aarch64.zip" from
+#   https://github.com/guysoft/opencode-termux/releases/latest
+# Then install:
+
+mkdir -p $PREFIX/libexec/opencode $PREFIX/lib
+unzip opencode-*-android-aarch64.zip
+mv opencode $PREFIX/bin/opencode
+chmod +x $PREFIX/bin/opencode
+mv opencode.bin $PREFIX/libexec/opencode/opencode.bin
+chmod +x $PREFIX/libexec/opencode/opencode.bin
+mv libtagfix.so libc++_shared.so libopentui.so $PREFIX/lib/
 
 # Install required dependency
 pkg install ripgrep


### PR DESCRIPTION
The standalone zip now ships 5 files (opencode wrapper + opencode.bin
+ libtagfix.so + libc++_shared.so + libopentui.so), but the install
docs assumed a single binary and used a broken download URL.

Problems fixed:
- Old instructions (`mv opencode $PREFIX/bin/`) isolated the wrapper
  from opencode.bin and .so files, causing launch failure.
- Download URL pointed to `opencode-aarch64.zip` but the actual asset
  is named `opencode-$VERSION-android-aarch64.zip`, returning 404.

Fix: install files to their proper Termux locations following the
standard package layout:

  $PREFIX/bin/opencode              (wrapper — user-facing executable)
  $PREFIX/libexec/opencode/opencode.bin  (internal binary)
  $PREFIX/lib/*.so                  (shared libraries)

This follows the Termux file system conventions:
https://github.com/termux/termux-packages/wiki/Termux-file-system-layout

Tested on:
- Samsung Galaxy S23 (SM-S911B), Android 16, Termux F-Droid 0.118.3
- aarch64, opencode v1.17.9