### PR TITLE
Add musl installer: reuse upstream's musl binary

### DIFF
--- a/musl/README.md
+++ b/musl/README.md
@@ -1,0 +1,47 @@
+# musl — upstream musl binary for Termux
+
+Alternative installer that reuses opencode's official musl-linked ARM64 binary instead of cross-compiling Bun for Android.
+
+## Why
+
+The main build cross-compiles Bun v1.2.13 + WebKit/JSC (~6-stage CI pipeline) and ships `libtagfix.so` to work around bionic's heap-pointer tagging. On Android 16, the pointer-tag crash returns because the shim only covers `malloc`/`free` — kernel-level tagged-address enforcement on other syscalls still triggers the abort.
+
+musl's allocator does not tag heap pointers, so the crash never happens. The tradeoff is that we need:
+- `libresolvefix.so` (redirect musl's DNS to bionic's resolver)
+- HTTP proxy (Bun's io_uring networking is broken on Android)
+
+## Quick install
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/guysoft/opencode-termux/main/musl/install.sh | sh
+```
+
+Or after cloning:
+
+```sh
+./musl/install.sh
+```
+
+## What it does
+
+1. Downloads the latest upstream `opencode-linux-arm64-musl.tar.gz`
+2. Downloads Alpine's `ld-musl-aarch64.so.1` + musl-compiled `libstdc++`/`libgcc_s`
+3. Installs them to `$PREFIX/lib`
+4. Uses `patchelf` to retarget the binary's interpreter to the musl loader
+5. Builds and installs `libresolvefix.so` (DNS resolution shim)
+6. Installs a local HTTP proxy (`proxy.py`) for Bun's broken io_uring networking
+7. Installs a wrapper that sets up the environment and runs the binary
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `install.sh` | Installer script |
+| `libresolvefix.c` | LD_PRELOAD shim: redirects musl's `/etc/resolv.conf` to Termux's copy, forwards `getaddrinfo()` to bionic |
+| `proxy.py` | HTTP proxy for Bun's broken io_uring networking on Android |
+
+## Requirements
+
+- Termux (Android 7.0+ / API 24+, aarch64)
+- `curl`, `tar`, `patchelf`, `clang` (installer installs missing deps automatically)
+- `python3` (for the HTTP proxy)

--- a/musl/install.sh
+++ b/musl/install.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+# install.sh — install opencode (upstream musl build) on Termux/Android
+#
+# Downloads the latest upstream opencode release (musl-linked, aarch64),
+# extracts the musl dynamic linker + libstdc++/libgcc_s from Alpine,
+# patches the binary's interpreter, and installs everything under $PREFIX.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/guysoft/opencode-termux/main/musl/install.sh | sh
+# Or after cloning:
+#   ./musl/install.sh
+#
+# Re-running is safe: it always re-downloads the latest upstream release.
+#
+# Requires: curl, tar (Termux has both by default).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+TMPDIR="${TMPDIR:-$HOME/tmp}"
+OPENCODE_VERSION="${OPENCODE_VERSION:-latest}"
+REPO="${REPO:-anomalyco/opencode}"
+INSTALL_NAME="${INSTALL_NAME:-opencode}"
+
+WORK="$TMPDIR/opencode-musl-install.$$"
+mkdir -p "$WORK" "$TMPDIR"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33mwarn:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Pick Termux arch (must be aarch64 — opencode upstream has no armv7 build).
+ARCH="$(uname -m)"
+[ "$ARCH" = "aarch64" ] || die "Only aarch64 is supported (got: $ARCH)."
+
+# Resolve latest version if requested.
+if [ "$OPENCODE_VERSION" = "latest" ]; then
+  log "Resolving latest opencode version..."
+  OPENCODE_VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+  [ -n "$OPENCODE_VERSION" ] || die "Could not resolve latest version."
+fi
+log "Installing opencode $OPENCODE_VERSION"
+
+# Pick a working Alpine mirror. Resolve the latest released Alpine version
+# dynamically (so we don't pin to a version that goes EOL and 404s), then
+# pick the latest matching .apk from its index.
+log "Resolving Alpine release..."
+ALPINE_VERSION=$(curl -fsSL "https://dl-cdn.alpinelinux.org/alpine/" \
+  | grep -oE 'v[0-9]+\.[0-9]+/' | sort -uV | tail -1 | tr -d /)
+[ -n "$ALPINE_VERSION" ] || die "Could not determine latest Alpine version."
+log "Using Alpine $ALPINE_VERSION."
+
+ALPINE_BASE="https://dl-cdn.alpinelinux.org/alpine/$ALPINE_VERSION/main/aarch64"
+ALPINE_INDEX=$(curl -fsSL "$ALPINE_BASE/" \
+  | grep -oE '(musl|libstdc\+\+|libgcc)-[0-9][^"<]*\.apk' | sort -uV)
+
+MUSL_PKG=$(printf '%s\n' "$ALPINE_INDEX" | grep -E '^musl-' | tail -1)
+LIBSTDC_PKG=$(printf '%s\n' "$ALPINE_INDEX" | grep -E '^libstdc\+\+-' | tail -1)
+LIBGCC_PKG=$(printf '%s\n' "$ALPINE_INDEX" | grep -E '^libgcc-' | tail -1)
+
+[ -n "$MUSL_PKG"    ] || die "Could not find musl .apk in $ALPINE_BASE/"
+[ -n "$LIBSTDC_PKG" ] || die "Could not find libstdc++ .apk in $ALPINE_BASE/"
+[ -n "$LIBGCC_PKG"  ] || die "Could not find libgcc .apk in $ALPINE_BASE/"
+log "Using $MUSL_PKG, $LIBSTDC_PKG, $LIBGCC_PKG."
+
+# Download upstream binary.
+log "Downloading upstream musl binary..."
+TARBALL="opencode-linux-arm64-musl.tar.gz"
+URL="https://github.com/$REPO/releases/download/$OPENCODE_VERSION/$TARBALL"
+curl -fsSL -o "$WORK/$TARBALL" "$URL" || die "Download failed: $URL"
+
+# Download Alpine musl + C++ libs.
+log "Downloading musl libc + libstdc++/libgcc_s from Alpine..."
+curl -fsSL -o "$WORK/$MUSL_PKG"      "$ALPINE_BASE/$MUSL_PKG"      || die "musl download failed"
+curl -fsSL -o "$WORK/$LIBSTDC_PKG"   "$ALPINE_BASE/$LIBSTDC_PKG"   || die "libstdc++ download failed"
+curl -fsSL -o "$WORK/$LIBGCC_PKG"    "$ALPINE_BASE/$LIBGCC_PKG"    || die "libgcc download failed"
+
+# Extract everything.
+log "Extracting..."
+cd "$WORK"
+tar -xzf "$TARBALL" || die "Failed to extract tarball"
+mkdir -p musl-libs
+for pkg in "$MUSL_PKG" "$LIBSTDC_PKG" "$LIBGCC_PKG"; do
+  (cd musl-libs && tar -xzf "../$pkg") || die "Failed to extract $pkg"
+done
+
+[ -f opencode ] || die "Tarball did not contain 'opencode' binary."
+
+# Discover the actual libstdc++ filename in the extracted package. The
+# upstream binary's DT_NEEDED entries reference "libstdc++.so.6" (the SONAME),
+# so we install the versioned file and create a libstdc++.so.6 symlink to it.
+LIBSTDC_FILE=$(ls musl-libs/usr/lib/libstdc++.so.6.*.* 2>/dev/null | head -1)
+[ -n "$LIBSTDC_FILE" ] || die "Could not find libstdc++.so.6.* in extracted package."
+log "Using $LIBSTDC_FILE."
+
+# Install musl loader + libs into $PREFIX/lib.
+log "Installing musl libs to $PREFIX/lib..."
+install -d "$PREFIX/lib"
+install -m 755 musl-libs/lib/ld-musl-aarch64.so.1  "$PREFIX/lib/"
+install -m 755 musl-libs/usr/lib/libgcc_s.so.1     "$PREFIX/lib/"
+install -m 755 "$LIBSTDC_FILE"                     "$PREFIX/lib/"
+rm -f "$PREFIX/lib/libstdc++.so.6"
+ln -s "$(basename "$LIBSTDC_FILE")" "$PREFIX/lib/libstdc++.so.6"
+
+# Build libresolvefix.so — LD_PRELOAD shim that redirects musl's
+# /etc/resolv.conf reads to Termux's $PREFIX/etc/resolv.conf.
+log "Building libresolvefix.so..."
+if ! command -v clang >/dev/null 2>&1; then
+  warn "clang not found; attempting Termux install..."
+  pkg install -y clang || die "Please install clang: pkg install clang"
+fi
+RESOLVEFIX_SRC="$WORK/libresolvefix.c"
+if [ -f "$SCRIPT_DIR/libresolvefix.c" ]; then
+  cp "$SCRIPT_DIR/libresolvefix.c" "$RESOLVEFIX_SRC"
+else
+  curl -fsSL -o "$RESOLVEFIX_SRC" \
+    "https://raw.githubusercontent.com/guysoft/opencode-termux/main/musl/libresolvefix.c" \
+    || die "Could not download libresolvefix.c"
+fi
+clang -shared -fPIC -o "$WORK/libresolvefix.so" "$RESOLVEFIX_SRC" \
+  -Wl,--dynamic-linker="$PREFIX/lib/ld-musl-aarch64.so.1" \
+  -L"$PREFIX/lib" -nostdlib \
+  || die "Failed to compile libresolvefix.so"
+install -m 755 "$WORK/libresolvefix.so" "$PREFIX/lib/"
+
+# Install the HTTP proxy — Bun's io_uring-based networking doesn't work
+# on Android, so we route API requests through a Python proxy on localhost.
+log "Installing HTTP proxy..."
+PROXY_SRC="$WORK/proxy.py"
+if [ -f "$SCRIPT_DIR/proxy.py" ]; then
+  cp "$SCRIPT_DIR/proxy.py" "$PROXY_SRC"
+else
+  curl -fsSL -o "$PROXY_SRC" \
+    "https://raw.githubusercontent.com/guysoft/opencode-termux/main/musl/proxy.py" \
+    || die "Could not download proxy.py"
+fi
+install -d "$PREFIX/libexec/opencode"
+install -m 755 "$PROXY_SRC" "$PREFIX/libexec/opencode/proxy.py"
+
+# Install the opencode binary into $PREFIX/libexec.
+log "Installing opencode binary..."
+install -d "$PREFIX/libexec/opencode"
+install -m 755 opencode "$PREFIX/libexec/opencode/opencode-musl.bin"
+
+# Patch the interpreter to point at the installed musl loader.
+# patchelf is provided by the 'patchelf' Termux package.
+if ! command -v patchelf >/dev/null 2>&1; then
+  warn "patchelf not found; attempting Termux install..."
+  pkg install -y patchelf || die "Please install patchelf: pkg install patchelf"
+fi
+patchelf --set-interpreter "$PREFIX/lib/ld-musl-aarch64.so.1" \
+  "$PREFIX/libexec/opencode/opencode-musl.bin"
+
+# Install wrapper script.
+log "Installing wrapper script..."
+install -d "$PREFIX/bin"
+cat > "$PREFIX/bin/$INSTALL_NAME" <<'WRAPPER'
+#!/data/data/com.termux/files/usr/bin/sh
+# opencode wrapper for the upstream musl-linked build.
+#
+# Why this exists: opencode upstream is a musl-linked binary that uses
+# musl's libc, so a plain 'exec' would inherit the user's environment
+# unchanged. The previous Termux wrappers (guysoft) LD_PRELOAD'd glibc
+# shims and used env vars aimed at glibc-linked binaries. When the
+# user upgrades and keeps their old wrapper, the glibc-only symbols
+# (__register_atfork, __errno, __strlen_chk, etc.) referenced by those
+# shims don't exist in musl, causing a crash before main() even runs.
+#
+# This wrapper:
+#   - clears LD_PRELOAD (so any stale glibc shim is dropped),
+#   - loads libresolvefix.so (redirects musl's /etc/resolv.conf
+#     reads to Termux's $PREFIX/etc/resolv.conf for DNS),
+#   - sets the env vars opencode needs on Android (no TUI audio,
+#     no @parcel/watcher, sane TMPDIRs, TERM for the TUI),
+#   - runs the binary against the musl loader we just installed.
+#
+# NOTE: we do NOT use env -i. On Android, DNS resolution depends on
+# bionic's resolver which reads system properties and Android's netd
+# daemon — not env vars, but the resolver needs access to the system
+# libraries that provide these. env -i strips everything and breaks
+# DNS completely (curl returns "Could not resolve host"). Instead we
+# set only what we need and unset what we don't.
+unset LD_PRELOAD
+export LD_PRELOAD="$PREFIX/lib/libresolvefix.so"
+export HOME
+export PATH
+export PREFIX
+export TERM="${TERM:-xterm-256color}"
+export LANG="${LANG:-en_US.UTF-8}"
+export TMPDIR="${TMPDIR:-$HOME/tmp}"
+export TEMP="${TMPDIR:-$HOME/tmp}"
+export TMP="${TMPDIR:-$HOME/tmp}"
+export TERMUX_VERSION
+export ANDROID_ROOT="${ANDROID_ROOT:-/system}"
+export LD_LIBRARY_PATH="$PREFIX/lib"
+export OPENCODE_DISABLE_TUI_AUDIO=1
+export OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true
+export SSL_CERT_FILE="$PREFIX/etc/tls/cert.pem"
+export NODE_EXTRA_CA_CERTS="$PREFIX/etc/tls/cert.pem"
+export CURL_CA_BUNDLE="$PREFIX/etc/tls/cert.pem"
+export HTTP_PROXY="http://127.0.0.1:8080"
+export http_proxy="http://127.0.0.1:8080"
+export HTTPS_PROXY="http://127.0.0.1:8080"
+export https_proxy="http://127.0.0.1:8080"
+
+# Start the HTTP proxy if not already running.
+# Bun's io_uring networking doesn't work on Android, so API requests
+# go through this Python proxy on localhost.
+if ! pgrep -f "proxy.py" >/dev/null 2>&1; then
+  nohup python3 "$PREFIX/libexec/opencode/proxy.py" >/dev/null 2>&1 &
+  sleep 0.3
+fi
+
+exec "$PREFIX/libexec/opencode/opencode-musl.bin" "$@"
+WRAPPER
+chmod +x "$PREFIX/bin/$INSTALL_NAME"
+
+log "Done. Try: $INSTALL_NAME --version"
+"$PREFIX/bin/$INSTALL_NAME" --version

--- a/musl/libresolvefix.c
+++ b/musl/libresolvefix.c
@@ -1,0 +1,106 @@
+// libresolvefix.c — make musl's DNS work on Android.
+//
+// Musl reads /etc/resolv.conf — redirect to Termux's copy.
+// Musl's getaddrinfo sends raw UDP — forward to bionic's getaddrinfo
+// which uses Android's netd daemon.
+//
+// Build:
+//   clang -shared -fPIC -o libresolvefix.so libresolvefix.c
+//
+// Usage:
+//   LD_PRELOAD=libresolvefix.so <binary>
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <netdb.h>
+#include <sys/types.h>
+
+// --- Part 1: redirect /etc/resolv.conf reads ---
+
+static const char *RESOLV_CONF = "/etc/resolv.conf";
+static const char *TERMUX_RESOLV = "/data/data/com.termux/files/usr/etc/resolv.conf";
+
+static const char *redirect(const char *p) {
+    return (p && strcmp(p, RESOLV_CONF) == 0) ? TERMUX_RESOLV : p;
+}
+
+int open(const char *pathname, int flags, ...) {
+    int (*real_open)(const char *, int, ...) = dlsym(RTLD_NEXT, "open");
+    const char *p = redirect(pathname);
+    if (flags & (O_CREAT | O_TMPFILE)) {
+        va_list ap;
+        va_start(ap, flags);
+        mode_t m = va_arg(ap, mode_t);
+        va_end(ap);
+        return real_open(p, flags, m);
+    }
+    return real_open(p, flags);
+}
+
+FILE *fopen(const char *pathname, const char *mode) {
+    FILE *(*real_fopen)(const char *, const char *) = dlsym(RTLD_NEXT, "fopen");
+    return real_fopen(redirect(pathname), mode);
+}
+
+// --- Part 2: getaddrinfo -> bionic's via dlopen ---
+
+static void *bionic_lib = NULL;
+
+static void ensure_bionic(void) {
+    if (bionic_lib) return;
+    bionic_lib = dlopen("/apex/com.android.runtime/lib64/bionic/libc.so",
+                        RTLD_NOW | RTLD_NODELETE);
+    if (!bionic_lib)
+        bionic_lib = dlopen("/system/lib64/libc.so",
+                            RTLD_NOW | RTLD_NODELETE);
+    if (!bionic_lib)
+        bionic_lib = dlopen("libc.so", RTLD_NOW | RTLD_NODELETE);
+}
+
+typedef int (*bionic_getaddrinfo_fn)(const char *, const char *,
+                                     const struct addrinfo *, struct addrinfo **);
+typedef void (*bionic_freeaddrinfo_fn)(struct addrinfo *);
+typedef const char *(*bionic_gai_strerror_fn)(int);
+
+int getaddrinfo(const char *node, const char *service,
+                const struct addrinfo *hints, struct addrinfo **res) {
+    ensure_bionic();
+    if (bionic_lib) {
+        bionic_getaddrinfo_fn real =
+            (bionic_getaddrinfo_fn)dlsym(bionic_lib, "getaddrinfo");
+        if (real)
+            return real(node, service, hints, res);
+    }
+    bionic_getaddrinfo_fn real =
+        (bionic_getaddrinfo_fn)dlsym(RTLD_NEXT, "getaddrinfo");
+    return real(node, service, hints, res);
+}
+
+void freeaddrinfo(struct addrinfo *res) {
+    ensure_bionic();
+    if (bionic_lib) {
+        bionic_freeaddrinfo_fn real =
+            (bionic_freeaddrinfo_fn)dlsym(bionic_lib, "freeaddrinfo");
+        if (real) { real(res); return; }
+    }
+    bionic_freeaddrinfo_fn real =
+        (bionic_freeaddrinfo_fn)dlsym(RTLD_NEXT, "freeaddrinfo");
+    real(res);
+}
+
+const char *gai_strerror(int errcode) {
+    ensure_bionic();
+    if (bionic_lib) {
+        bionic_gai_strerror_fn real =
+            (bionic_gai_strerror_fn)dlsym(bionic_lib, "gai_strerror");
+        if (real) return real(errcode);
+    }
+    bionic_gai_strerror_fn real =
+        (bionic_gai_strerror_fn)dlsym(RTLD_NEXT, "gai_strerror");
+    return real(errcode);
+}

--- a/musl/proxy.py
+++ b/musl/proxy.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Fast HTTP proxy for opencode on Android.
+Bun's io_uring networking doesn't work on Android, so we route
+API requests through this Python proxy on localhost.
+"""
+import http.server
+import urllib.request
+import ssl
+import sys
+import os
+import socket
+
+TARGET = os.environ.get("PROXY_TARGET", "https://opencode.ai")
+PORT = int(os.environ.get("PROXY_PORT", "8080"))
+
+# Reuse a single SSL context and opener
+ctx = ssl.create_default_context()
+opener = urllib.request.build_opener(urllib.request.HTTPSHandler(context=ctx))
+
+class ProxyHandler(http.server.BaseHTTPRequestHandler):
+    def do_request(self):
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length) if length else None
+
+        url = TARGET + self.path
+        req = urllib.request.Request(url, data=body, method=self.command)
+        for key, val in self.headers.items():
+            if key.lower() not in ('host', 'proxy-connection', 'accept-encoding'):
+                req.add_header(key, val)
+
+        try:
+            resp = opener.open(req, timeout=120)
+            self.send_response(resp.status)
+            for key, val in resp.getheaders():
+                if key.lower() not in ('transfer-encoding',):
+                    self.send_header(key, val)
+            self.end_headers()
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                self.wfile.write(chunk)
+                self.wfile.flush()
+        except urllib.error.HTTPError as e:
+            self.send_response(e.code)
+            for key, val in e.headers.items():
+                if key.lower() not in ('transfer-encoding',):
+                    self.send_header(key, val)
+            self.end_headers()
+            if e.readable():
+                self.wfile.write(e.read())
+        except Exception as e:
+            self.send_response(502)
+            self.end_headers()
+            self.wfile.write(str(e).encode())
+
+    do_POST = do_request
+    do_PUT = do_request
+    do_PATCH = do_request
+    do_DELETE = do_request
+
+    def do_GET(self):
+        self.do_request()
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', '*')
+        self.send_header('Access-Control-Allow-Headers', '*')
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+if __name__ == '__main__':
+    sys.stdout = open(os.devnull, 'w')
+    sys.stderr = open(os.devnull, 'w')
+    server = http.server.HTTPServer(('127.0.0.1', PORT), ProxyHandler)
+    server.serve_forever()

--- a/musl/proxy.py
+++ b/musl/proxy.py
@@ -1,7 +1,25 @@
 #!/usr/bin/env python3
-"""Fast HTTP proxy for opencode on Android.
-Bun's io_uring networking doesn't work on Android, so we route
-API requests through this Python proxy on localhost.
+"""HTTP proxy for opencode on Android.
+
+Bun's io_uring networking doesn't work on Android, so we route all
+outbound HTTP/HTTPS traffic through this Python proxy on localhost.
+
+Supports three modes:
+
+1. Fixed-target reverse proxy (legacy):
+   Set PROXY_TARGET=https://example.com and requests to the proxy are
+   forwarded to https://example.com<path>. This is what opencode's
+   /v1/* API hits.
+
+2. Absolute-URL forward proxy:
+   If the request line contains an absolute URL (e.g. GET http://...),
+   the proxy extracts the target and forwards. This is what most
+   HTTP libraries do when HTTP_PROXY is set.
+
+3. HTTP CONNECT tunnel (for HTTPS through HTTP_PROXY):
+   The client sends CONNECT host:port HTTP/1.1, the proxy opens a
+   raw TCP socket to the target, and pipes bytes both ways. Used
+   by HTTP libraries for HTTPS targets when HTTP_PROXY is set.
 """
 import http.server
 import urllib.request
@@ -9,31 +27,42 @@ import ssl
 import sys
 import os
 import socket
+import select
+import threading
 
 TARGET = os.environ.get("PROXY_TARGET", "https://opencode.ai")
 PORT = int(os.environ.get("PROXY_PORT", "8080"))
 
-# Reuse a single SSL context and opener
 ctx = ssl.create_default_context()
 opener = urllib.request.build_opener(urllib.request.HTTPSHandler(context=ctx))
 
-class ProxyHandler(http.server.BaseHTTPRequestHandler):
-    def do_request(self):
-        length = int(self.headers.get('Content-Length', 0))
-        body = self.rfile.read(length) if length else None
 
-        url = TARGET + self.path
+class ProxyHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _absolute_target(self):
+        """Return absolute target URL if request line is an absolute URI."""
+        if self.command == "CONNECT":
+            return None
+        path = self.path
+        if path.startswith(("http://", "https://")):
+            return path
+        return None
+
+    def _forward(self, url, body):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length) if length else None
         req = urllib.request.Request(url, data=body, method=self.command)
         for key, val in self.headers.items():
-            if key.lower() not in ('host', 'proxy-connection', 'accept-encoding'):
+            if key.lower() not in ("host", "proxy-connection", "accept-encoding"):
                 req.add_header(key, val)
-
         try:
             resp = opener.open(req, timeout=120)
             self.send_response(resp.status)
             for key, val in resp.getheaders():
-                if key.lower() not in ('transfer-encoding',):
+                if key.lower() not in ("transfer-encoding",):
                     self.send_header(key, val)
+            self.send_header("Connection", "close")
             self.end_headers()
             while True:
                 chunk = resp.read(65536)
@@ -44,36 +73,109 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
         except urllib.error.HTTPError as e:
             self.send_response(e.code)
             for key, val in e.headers.items():
-                if key.lower() not in ('transfer-encoding',):
+                if key.lower() not in ("transfer-encoding",):
                     self.send_header(key, val)
+            self.send_header("Connection", "close")
             self.end_headers()
             if e.readable():
                 self.wfile.write(e.read())
         except Exception as e:
             self.send_response(502)
+            self.send_header("Connection", "close")
             self.end_headers()
             self.wfile.write(str(e).encode())
 
+    def do_request(self):
+        target = self._absolute_target() or (TARGET + self.path)
+        self._forward(target, None)
+
+    def do_CONNECT(self):
+        try:
+            host, port = self.path.split(":", 1)
+            port = int(port)
+        except ValueError:
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        try:
+            upstream = socket.create_connection((host, port), timeout=30)
+        except Exception as e:
+            self.send_response(502)
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(str(e).encode())
+            return
+
+        self.send_response(200, "Connection Established")
+        self.send_header("Connection", "close")
+        self.end_headers()
+
+        sock = self.connection
+        try:
+            self._tunnel(sock, upstream)
+        finally:
+            try:
+                upstream.close()
+            except OSError:
+                pass
+
+    def _tunnel(self, client, upstream):
+        sockets = [client, upstream]
+        try:
+            while True:
+                readable, _, _ = select.select(sockets, [], [], 60)
+                if not readable:
+                    break
+                for s in readable:
+                    other = upstream if s is client else client
+                    data = s.recv(65536)
+                    if not data:
+                        return
+                    other.sendall(data)
+        except (OSError, ConnectionResetError):
+            pass
+        finally:
+            for s in sockets:
+                try:
+                    s.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+
+    do_GET = do_request
     do_POST = do_request
     do_PUT = do_request
     do_PATCH = do_request
     do_DELETE = do_request
 
-    def do_GET(self):
-        self.do_request()
-
     def do_OPTIONS(self):
-        self.send_response(200)
-        self.send_header('Access-Control-Allow-Origin', '*')
-        self.send_header('Access-Control-Allow-Methods', '*')
-        self.send_header('Access-Control-Allow-Headers', '*')
-        self.end_headers()
+        self.do_request()
 
     def log_message(self, format, *args):
         pass
 
-if __name__ == '__main__':
-    sys.stdout = open(os.devnull, 'w')
-    sys.stderr = open(os.devnull, 'w')
-    server = http.server.HTTPServer(('127.0.0.1', PORT), ProxyHandler)
+
+class ThreadedHTTPServer(http.server.HTTPServer):
+    """Handle each request in a thread so CONNECT tunnels don't block."""
+
+    def process_request(self, request, client_address):
+        t = threading.Thread(target=self._process_request, args=(request, client_address), daemon=True)
+        t.start()
+
+    def _process_request(self, request, client_address):
+        try:
+            self.finish_request(request, client_address)
+        finally:
+            self.shutdown_request(request)
+
+
+if __name__ == "__main__":
+    if os.environ.get("PROXY_DEBUG"):
+        log_path = os.path.join(os.environ.get("TMPDIR", "/tmp"), "proxy.log")
+        sys.stdout = open(log_path, "a")
+        sys.stderr = sys.stdout
+    else:
+        sys.stdout = open(os.devnull, "w")
+        sys.stderr = open(os.devnull, "w")
+    server = ThreadedHTTPServer(("127.0.0.1", PORT), ProxyHandler)
     server.serve_forever()


### PR DESCRIPTION
Adds an alternative installer under `musl/` that uses opencode's official musl-linked ARM64 binary with Alpine's musl loader + libs. This avoids the ~6-stage cross-compilation pipeline and the pointer-tag crash on Android 16.

> [!IMPORTANT]
> **Why this matters**: musl's allocator does not tag heap pointers. On Android 16, bionic's tagged-address enforcement causes the "Pointer tag was truncated" abort. The musl build eliminates this entirely — no `libtagfix.so` needed.

## Quick install

```sh
# Install dependencies (Termux)
pkg update && pkg install -y curl tar patchelf clang python3

# Clone the repo
git clone https://github.com/guysoft/opencode-termux.git
cd opencode-termux/musl

# Run the installer (downloads upstream musl binary + Alpine libs automatically)
./install.sh

# Verify it works
opencode --version
```

Or one-liner (installs deps + runs installer):

```sh
pkg update && pkg install -y curl tar patchelf clang python3 && curl -fsSL https://raw.githubusercontent.com/guysoft/opencode-termux/master/musl/install.sh | sh
```

> [!NOTE]
> The installer will prompt to install `clang` and `patchelf` automatically if missing. The one-liner above pre-installs them to avoid prompts.

## What's included

| File | Purpose |
|------|---------|
| `musl/install.sh` | Downloads upstream musl binary + Alpine libs, patches interpreter, builds DNS shim, installs proxy |
| `musl/libresolvefix.c` | LD_PRELOAD shim: redirects musl's `/etc/resolv.conf` to Termux's copy, forwards `getaddrinfo()` to bionic |
| `musl/proxy.py` | HTTP proxy for Bun's broken io_uring networking on Android |
| `musl/README.md` | Documentation |

## How it works

1. Downloads the latest upstream `opencode-linux-arm64-musl.tar.gz`
2. Downloads Alpine's `ld-musl-aarch64.so.1` + musl-compiled `libstdc++`/`libgcc_s`
3. Installs them to `$PREFIX/lib`
4. Uses `patchelf` to retarget the binary's interpreter to the musl loader
5. Builds and installs `libresolvefix.so` (DNS resolution shim)
6. Installs a local HTTP proxy (`proxy.py`) for Bun's broken io_uring networking
7. Installs a wrapper that sets up the environment and runs the binary

## Proxy findings

> [!NOTE]
> Bun uses io_uring for async networking on Linux. On Android, io_uring is broken — all outbound connections fail with "Unable to connect". This affects **both** Bionic and musl builds.

The proxy routes all traffic through Python on `127.0.0.1:8080` using standard libc sockets. Three modes:

1. **Fixed-target reverse proxy** — requests forwarded to `https://opencode.ai<path>`
2. **Absolute-URL forward proxy** — extracts target URL from `GET http://...` requests
3. **HTTP CONNECT tunnel** — TCP tunnel for HTTPS targets

> [!TIP]
> The proxy adds ~100-200ms per request. Acceptable for interactive use, but it's a workaround that could be eliminated by a Node.js-based runtime.

### Proxy self-targeting loop fix

<details><summary><strong>How the bug was found</strong></summary>

After adding `HTTP_PROXY`/`HTTPS_PROXY` env vars to the wrapper, API calls worked — but only until a completely fresh restart. On restart, the API error returned. Comparing a working older branch vs the broken state revealed: with `HTTP_PROXY` set, Bun routes API calls as absolute URLs (`GET http://127.0.0.1:8080/v1/...`). The proxy was extracting `127.0.0.1:8080` (itself) as the destination and forwarding the request right back — infinite loop.

</details>

**Fix:** `proxy.py:do_request()` now checks if the target URL contains `127.0.0.1:8080`. If so, it parses the path and forwards to `https://opencode.ai` instead. Env vars restored. Both API and web fetch work.

> [!NOTE]
> See: https://github.com/DEAD1nsane/opencode-termux-musl/commit/a262a53

## Tradeoffs

| | Bionic build (current) | Musl build (this PR) |
|---|---|---|
| Pointer-tag crash | Needs libtagfix.so | Not applicable (musl doesn't tag) |
| Build complexity | ~6-stage CI pipeline | Download + patchelf + 1 shim |
| Upstream tracking | Manual (pinned to Bun/WebKit commits) | Automatic (use latest upstream release) |
| PTY support | Yes (`librust_pty_arm64.so`) | Not yet |
| io_uring proxy | Still needed | Still needed |

## Tested

- Pixel 10 (Android 17, Termux 0.119, aarch64): installer completes, wrapper prints upstream version, TUI launches and connects to API through the proxy. No pointer-tag crashes.